### PR TITLE
Выставление даты аукциона в двухэтапном тендере

### DIFF
--- a/openprocurement/tender/twostage/models.py
+++ b/openprocurement/tender/twostage/models.py
@@ -204,12 +204,10 @@ class TenderAuctionPeriod(Period):
         if self.endDate:
             return
         tender = self.__parent__
-        if tender.lots or tender.status not in ['active.tendering', 'active.pre-qualification.stand-still', 'active.auction']:
+        if tender.lots or tender.status not in ['active.pre-qualification.stand-still', 'active.auction']:
             return
         start_after = None
-        if tender.status == 'active.tendering' and tender.tenderPeriod.endDate:
-            start_after = calculate_business_date(tender.tenderPeriod.endDate, TENDERING_AUCTION, tender)
-        elif self.startDate and get_now() > calc_auction_end_time(tender.numberOfBids, self.startDate):
+        if self.startDate and get_now() > calc_auction_end_time(tender.numberOfBids, self.startDate):
             start_after = calc_auction_end_time(tender.numberOfBids, self.startDate)
         elif tender.qualificationPeriod and tender.qualificationPeriod.endDate:
             start_after = tender.qualificationPeriod.endDate
@@ -226,12 +224,10 @@ class LotAuctionPeriod(Period):
             return
         tender = get_tender(self)
         lot = self.__parent__
-        if tender.status not in ['active.tendering', 'active.pre-qualification.stand-still', 'active.auction'] or lot.status != 'active':
+        if tender.status not in ['active.pre-qualification.stand-still', 'active.auction'] or lot.status != 'active':
             return
         start_after = None
-        if tender.status == 'active.tendering' and tender.tenderPeriod.endDate:
-            start_after = calculate_business_date(tender.tenderPeriod.endDate, TENDERING_AUCTION, tender)
-        elif self.startDate and get_now() > calc_auction_end_time(lot.numberOfBids, self.startDate):
+        if self.startDate and get_now() > calc_auction_end_time(lot.numberOfBids, self.startDate):
             start_after = calc_auction_end_time(lot.numberOfBids, self.startDate)
         elif tender.qualificationPeriod and tender.qualificationPeriod.endDate:
             start_after = tender.qualificationPeriod.endDate

--- a/openprocurement/tender/twostage/tests/chronograph.py
+++ b/openprocurement/tender/twostage/tests/chronograph.py
@@ -94,7 +94,7 @@ class TenderSwitchUnsuccessfulResourceTest(BaseTenderContentWebTest):
 
 
 class TenderAuctionPeriodResourceTest(BaseTenderContentWebTest):
-    initial_status = 'active.tendering'
+    initial_status = 'active.pre-qualification.stand-still'
 
     def test_set_auction_period(self):
         self.app.authorization = ('Basic', ('chronograph', ''))

--- a/openprocurement/tender/twostage/utils.py
+++ b/openprocurement/tender/twostage/utils.py
@@ -105,6 +105,17 @@ def check_status(request):
     tender = request.validated['tender']
     now = get_now()
 
+    if tender.status in {'active.tendering', 'active.pre-qualification'}:
+        if tender.lots:
+            [
+                setattr(lot.auctionPeriod, 'startDate', None)
+                for lot in tender.lots
+                if lot.auctionPeriod and lot.auctionPeriod.startDate
+            ]
+        else:
+            if tender.auctionPeriod and tender.auctionPeriod.startDate:
+                tender.auctionPeriod.startDate = None
+
     if tender.status == 'active.tendering' and tender.tenderPeriod.endDate <= now:
         for complaint in tender.complaints:
             check_complaint_status(request, complaint)

--- a/openprocurement/tender/twostage/utils.py
+++ b/openprocurement/tender/twostage/utils.py
@@ -105,13 +105,11 @@ def check_status(request):
     tender = request.validated['tender']
     now = get_now()
 
-    if tender.status in {'active.tendering', 'active.pre-qualification'}:
+    if tender.status in ['active.tendering', 'active.pre-qualification']:
         if tender.lots:
-            [
-                setattr(lot.auctionPeriod, 'startDate', None)
-                for lot in tender.lots
-                if lot.auctionPeriod and lot.auctionPeriod.startDate
-            ]
+            for lot in tender.lots:
+                if lot.auctionPeriod and lot.auctionPeriod.startDate:
+                    lot.auctionPeriod.startDate = None
         else:
             if tender.auctionPeriod and tender.auctionPeriod.startDate:
                 tender.auctionPeriod.startDate = None


### PR DESCRIPTION
Проблема: 
В двухэтапном тендере дата аукциона назначается на этапе приема предложений, и при этом всегда переназначается на этапе обжалования преквалификации. Первая неверная дата вводит пользователей в заблуждение.
Решение:
Не выставлять дату начала аукциона пока тендер не перейдет в статус преквалификации период обжалования.